### PR TITLE
Postprocess/line probe

### DIFF
--- a/pyCM/postprocess.py
+++ b/pyCM/postprocess.py
@@ -131,6 +131,39 @@ class post_main_window(object):
 		self.updateButton = QtWidgets.QPushButton('Update')
 		self.updateButton.setMinimumWidth(50)
 
+		# line extraction from surface
+		extract_data_label = QtWidgets.QLabel("Extract")
+		extract_data_label.setFont(headFont)
+		extract_data_label.setWordWrap(True)
+		extract_data_label.setMinimumWidth(50)
+
+		# enter x and y of first point
+		point1_label = QtWidgets.QLabel("Point 1")
+		point1_label.setFont(headFont)
+		point1_label.setWordWrap(True)
+		point1_label.setMinimumWidth(50)
+		point1_x_label = QtWidgets.QLabel("X:")
+		self.point1_x_coord = QtWidgets.QLineEdit()
+		self.point1_x_coord.setMinimumWidth(50)
+		point1_y_label = QtWidgets.QLabel("Y:")
+		self.point1_y_coord = QtWidgets.QLineEdit()
+		self.point1_y_coord.setMinimumWidth(50)
+
+		# enter x and y of second point
+		point2_label = QtWidgets.QLabel("Point 2")
+		point2_label.setFont(headFont)
+		point2_label.setWordWrap(True)
+		point2_label.setMinimumWidth(50)
+		point2_x_label = QtWidgets.QLabel("X:")
+		self.point2_x_coord = QtWidgets.QLineEdit()
+		self.point2_x_coord.setMinimumWidth(50)
+		point2_y_label = QtWidgets.QLabel("Y:")
+		self.point2_y_coord = QtWidgets.QLineEdit()
+		self.point2_y_coord.setMinimumWidth(50)
+
+		# extract plot button
+		self.extractPlot = QtWidgets.QPushButton('Plot')
+		self.extractPlot.setMinimumWidth(50)
 
 		self.statLabel = QtWidgets.QLabel("Idle")
 		self.statLabel.setWordWrap(True)
@@ -153,6 +186,18 @@ class post_main_window(object):
 		mainUiBox.addWidget(self.inp_max_stress,9,1,1,1)
 		mainUiBox.addWidget(self.updateButton,9,0,1,2)
 		mainUiBox.addWidget(horiz_line2,10,0,1,2)
+		mainUiBox.addWidget(extract_data_label,11,0,1,1)
+		mainUiBox.addWidget(point1_label,12,0,1,1)
+		mainUiBox.addWidget(point1_x_label,13,0,1,1)
+		mainUiBox.addWidget(self.point1_x_coord,13,1,1,1)
+		mainUiBox.addWidget(point1_y_label,14,0,1,1)
+		mainUiBox.addWidget(self.point1_y_coord,14,1,1,1)
+		mainUiBox.addWidget(point2_label,15,0,1,1)
+		mainUiBox.addWidget(point2_x_label,16,0,1,1)
+		mainUiBox.addWidget(self.point2_x_coord,16,1,1,1)
+		mainUiBox.addWidget(point2_y_label,17,0,1,1)
+		mainUiBox.addWidget(self.point2_y_coord,17,1,1,1)
+		mainUiBox.addWidget(self.extractPlot,18,0,1,2)
 
 		lvLayout=QtWidgets.QVBoxLayout()
 		lvLayout.addLayout(mainUiBox)

--- a/pyCM/postprocess.py
+++ b/pyCM/postprocess.py
@@ -1015,6 +1015,13 @@ class pp_interactor(QtWidgets.QWidget):
 		line.SetPoint2(p2)
 		line.Update()
 		return line
+		
+	def setZeroToNaN(self, array):
+		"""
+		Escape zero value data as NaN
+		"""  
+		array[array==0] = np.nan
+		return array
 
 	def Keypress(self,obj, event):
 		key = obj.GetKeySym()

--- a/pyCM/postprocess.py
+++ b/pyCM/postprocess.py
@@ -1003,56 +1003,16 @@ class pp_interactor(QtWidgets.QWidget):
 					end_point_y = float(self.ui.point2_y_coord.text())
 					start_point = np.array([start_point_x, start_point_y, 1.])
 					end_point = np.array([end_point_x, end_point_y, 1.])
+				
+					pointsDict = {
+							 'start_point_x': start_point_x,
+							 'end_point_x': end_point_x,
+							 'start_point_y': start_point_y,
+							 'end_point_y': end_point_y,
+							 }
 					
-					# create points
-					points = vtk.vtkPoints()
-					points.SetNumberOfPoints(2)
-					points.SetPoint(0, start_point_x, start_point_y, 0.)
-					points.SetPoint(1, end_point_x, end_point_y, 0.)
+					points, U = self.probe_interpolation(pointsDict)
 
-					# create line as cell array to allow multiple points to be plotted
-					# when this function is extended for batch processing
-					# vtkCellArray is a cell array structure which represents cell connectivity
-					# of the form (n, id1, id2, ... , idn)
-					lines = vtk.vtkCellArray()
-					lines.InsertNextCell(2)
-					lines.InsertCellPoint(0)
-					lines.InsertCellPoint(1)
-
-					# polyline representing geometric structure of vertices and lines
-					polyline = vtk.vtkPolyData()
-					polyline.SetPoints(points)
-					polyline.SetLines(lines)
-					black_col = [0, 0, 0]
-					black_col_obgj = vtk.vtkUnsignedCharArray()
-					black_col_obgj.SetNumberOfComponents(3)
-					black_col_obgj.InsertNextTypedTuple(black_col)
-					polyline.GetCellData().SetScalars(black_col_obgj)
-
-					# create the polyline mapper
-					polyline_mapper = vtk.vtkPolyDataMapper()
-					polyline_mapper.SetInputData(polyline)
-					polyline_mapper.Update()
-
-					# create the polyline actor
-					self.polyline_actor = vtk.vtkActor()
-					self.polyline_actor.SetMapper(polyline_mapper)
-					self.polyline_actor.GetProperty().SetLineWidth(3)
-
-					# display actor
-					self.ren.AddActor(self.polyline_actor)
-
-					#force update of vtk interactor
-					self.ui.vtkWidget.update()
-					self.ui.vtkWidget.setFocus()
-					
-					p1 = [start_point_x, start_point_y, 1.]
-					p2 = [end_point_x, end_point_y, 1.]
-					numPoints = 1000
-
-					line = self.createLine(p1, p2, numPoints) # Create the line
-					points,U =  self.probeOverLine(line) # interpolate the data over the line
-					U = self.setZeroToNaN(U) # Set the zero's to NaN's
 					plt.plot(points[:,1], U[:]) #plot the data
 					plt.show()
 				else:
@@ -1069,6 +1029,91 @@ class pp_interactor(QtWidgets.QWidget):
 			msg.setWindowTitle("pyCM Error")
 			msg.exec_()
 			return
+
+	def probe_interpolation(self, pointsDict, numPoints = 1000):
+		"""
+		Generates interpolated values between two points for the active scalar field
+
+		Args:
+			pointsDict (Dictonary): dictionary storing the points
+				{
+					'start_point_x': start_point_x,
+					'end_point_x': end_point_x,
+					'start_point_y': start_point_y,
+					'end_point_y': end_point_y,
+				}
+			numPoints (int): number of points in the probe line
+		
+		Returns:
+			points (float[]): array (x, y, z) of the interpolated coordinate points
+			U (float[]): array (N) of the interpoated scalar field
+
+		Example:
+			>>> pointsDict = {
+							 'start_point_x': 30.,
+							 'end_point_x': 30.,
+							 'start_point_y': 100.,
+							 'end_point_y': 120.,
+							 }
+			>>> probe_interpolation(pointsDict)
+		"""
+
+		# load point values
+		start_point_x = pointsDict['start_point_x']
+		end_point_x = pointsDict['end_point_x']
+		start_point_y = pointsDict['start_point_y']
+		end_point_y = pointsDict['end_point_y']
+
+		# create points
+		points = vtk.vtkPoints()
+		points.SetNumberOfPoints(2)
+		points.SetPoint(0, start_point_x, start_point_y, 1.)
+		points.SetPoint(1, end_point_x, end_point_y, 1.)
+
+		# create line as cell array to allow multiple points to be plotted
+		# when this function is extended for batch processing
+		# vtkCellArray is a cell array structure which represents cell connectivity
+		# of the form (n, id1, id2, ... , idn)
+		lines = vtk.vtkCellArray()
+		lines.InsertNextCell(2)
+		lines.InsertCellPoint(0)
+		lines.InsertCellPoint(1)
+
+		# polyline representing geometric structure of vertices and lines
+		polyline = vtk.vtkPolyData()
+		polyline.SetPoints(points)
+		polyline.SetLines(lines)
+		black_col = [0, 0, 0]
+		black_col_obgj = vtk.vtkUnsignedCharArray()
+		black_col_obgj.SetNumberOfComponents(3)
+		black_col_obgj.InsertNextTypedTuple(black_col)
+		polyline.GetCellData().SetScalars(black_col_obgj)
+
+		# create the polyline mapper
+		polyline_mapper = vtk.vtkPolyDataMapper()
+		polyline_mapper.SetInputData(polyline)
+		polyline_mapper.Update()
+
+		# create the polyline actor
+		self.polyline_actor = vtk.vtkActor()
+		self.polyline_actor.SetMapper(polyline_mapper)
+		self.polyline_actor.GetProperty().SetLineWidth(3)
+
+		# display actor
+		self.ren.AddActor(self.polyline_actor)
+
+		#force update of vtk interactor
+		self.ui.vtkWidget.update()
+		self.ui.vtkWidget.setFocus()
+		
+		p1 = [start_point_x, start_point_y, 1.]
+		p2 = [end_point_x, end_point_y, 1.]
+
+		line = self.createLine(p1, p2, numPoints) # Create the line
+		points, U =  self.probeOverLine(line) # interpolate the data over the line
+		U = self.setZeroToNaN(U) # Set the zero's to NaN's		
+
+		return points, U
 
 	def probeOverLine(self, line):
 		"""

--- a/pyCM/postprocess.py
+++ b/pyCM/postprocess.py
@@ -256,6 +256,7 @@ class pp_interactor(QtWidgets.QWidget):
 				if not os.path.exists(self.vtk_file):
 					extract_from_mat(mat_contents['vtu_filename'][0],self.fileo,'vtu')
 				self.load_vtk_XML_file(self.vtk_file,'S33')
+				self.active_scalar_field = "S33"
 				
 			except Exception as e:
 				if 'FEA' in mat_contents: #there might be a dat file to read
@@ -534,7 +535,8 @@ class pp_interactor(QtWidgets.QWidget):
 		sio.savemat(self.fileo,mat_contents)
 
 		#show the result
-		self.load_vtk_XML_file(self.vtk_file,"S33")
+		self.active_scalar_field = "S33"
+		self.load_vtk_XML_file(self.vtk_file, active_scalar_field)
 		self.ui.statLabel.setText("Idle.")
 		
 	def update_stress_shown(self,field):
@@ -552,6 +554,9 @@ class pp_interactor(QtWidgets.QWidget):
 					self.mesh_mapper.SetScalarRange(scalar_range)
 					#update scale bar title
 					self.sbActor.SetTitle(field)
+					
+					#store active field
+					self.active_scalar_field = field
 
 					#update ui
 					self.ui.inp_min_stress.setText("%4.1f"%self.mesh_mapper.GetScalarRange()[0])
@@ -1073,7 +1078,7 @@ class pp_interactor(QtWidgets.QWidget):
 		probe.Update()
 
 		# get the data from the VTK-object (probe) to an numpy array
-		q = v2n(probe.GetOutput().GetPointData().GetArray('S33'))
+		q = v2n(probe.GetOutput().GetPointData().GetArray(self.active_scalar_field))
 		numPoints = probe.GetOutput().GetNumberOfPoints() # get the number of points on the line
 		
 		# intialise the points on the line    

--- a/pyCM/postprocess.py
+++ b/pyCM/postprocess.py
@@ -986,7 +986,7 @@ class pp_interactor(QtWidgets.QWidget):
 		for a line plot, however, it is implemented with vtkCellArray and vtkPolyData
 		to allow for polyline plots.
 		"""
-		field="S33"
+
 		if not self.vtk_file == None:
 				_, file_extension = os.path.splitext(self.vtk_file)
 				if file_extension == '.vtu' and os.path.isfile(self.vtk_file):

--- a/pyCM/postprocess.py
+++ b/pyCM/postprocess.py
@@ -1001,8 +1001,8 @@ class pp_interactor(QtWidgets.QWidget):
 					start_point_y = float(self.ui.point1_y_coord.text())
 					end_point_x = float(self.ui.point2_x_coord.text())
 					end_point_y = float(self.ui.point2_y_coord.text())
-					start_point = np.array([start_point_x, start_point_y, 0.])
-					end_point = np.array([end_point_x, end_point_y, 0.])
+					start_point = np.array([start_point_x, start_point_y, 1.])
+					end_point = np.array([end_point_x, end_point_y, 1.])
 					
 					# create points
 					points = vtk.vtkPoints()

--- a/pyCM/postprocess.py
+++ b/pyCM/postprocess.py
@@ -1014,6 +1014,8 @@ class pp_interactor(QtWidgets.QWidget):
 					points, U = self.probe_interpolation(pointsDict)
 
 					plt.plot(points[:,1], U[:]) #plot the data
+					plt.ylabel(self.active_scalar_field)
+					plt.xlabel("Distance along probe line")
 					plt.show()
 				else:
 					msg=QtWidgets.QMessageBox()

--- a/pyCM/postprocess.py
+++ b/pyCM/postprocess.py
@@ -1005,6 +1005,17 @@ class pp_interactor(QtWidgets.QWidget):
 			points[i, 2] = z[i]
 		return points, q
 
+	def createLine(self, p1, p2, numPoints):
+		"""
+		Create the sample line
+		"""  
+		line = vtk.vtkLineSource()
+		line.SetResolution(numPoints)
+		line.SetPoint1(p1)
+		line.SetPoint2(p2)
+		line.Update()
+		return line
+
 	def Keypress(self,obj, event):
 		key = obj.GetKeySym()
 		

--- a/pyCM/postprocess.py
+++ b/pyCM/postprocess.py
@@ -990,6 +990,12 @@ class pp_interactor(QtWidgets.QWidget):
 		if not self.vtk_file == None:
 				_, file_extension = os.path.splitext(self.vtk_file)
 				if file_extension == '.vtu' and os.path.isfile(self.vtk_file):
+
+					# the line actor will persist so if the extraction has been performed once already
+					# we need to remove it so only the new probe is plotted
+					if hasattr(self, "polyline_actor"):
+						self.ren.RemoveActor(self.polyline_actor)
+
 					# get start and end point coordinates
 					start_point_x = float(self.ui.point1_x_coord.text())
 					start_point_y = float(self.ui.point1_y_coord.text())

--- a/pyCM/postprocess.py
+++ b/pyCM/postprocess.py
@@ -974,6 +974,37 @@ class pp_interactor(QtWidgets.QWidget):
 
 		return shape_function_matrix
 
+	def probeOverLine(self, line):
+		"""
+		Interpolate the data from the VTK-file on the created line.
+		"""
+		data = self.mesh_reader_output
+		
+		probe = vtk.vtkProbeFilter()
+		#probe.SetInputConnection(line.GetOutputPort())
+		probe.SetInputConnection(line.GetOutputPort())
+		probe.SetSourceData(data)
+
+		probe.Update()
+
+		# get the data from the VTK-object (probe) to an numpy array
+		q = v2n(probe.GetOutput().GetPointData().GetArray('S33'))
+		numPoints = probe.GetOutput().GetNumberOfPoints() # get the number of points on the line
+		
+		# intialise the points on the line    
+		x = np.zeros(numPoints)
+		y = np.zeros(numPoints)
+		z = np.zeros(numPoints)
+		points = np.zeros((numPoints , 3))
+		
+		# get the coordinates of the points on the line
+		for i in range(numPoints):
+			x[i], y[i], z[i] = probe.GetOutput().GetPoint(i)
+			points[i, 0] = x[i]
+			points[i, 1] = y[i]
+			points[i, 2] = z[i]
+		return points, q
+
 	def Keypress(self,obj, event):
 		key = obj.GetKeySym()
 		


### PR DESCRIPTION
The pull request provides a line probe for the postprocessor. In the GUI it adds a simple interface to input x,y for two points on the surface and plots the active scalar field in a simple matplotlib graph. For automation the function which requires wrapping is ```probe_interpolation```. The function is called as below:

```python
pointsDict = {
'start_point_x': 30.,
'end_point_x': 30.,
'start_point_y': 100.,
'end_point_y': 120.,
 }
probe_interpolation(pointsDict)
```

It will then return two arrays which hold the x,y,z coordinates and the interpolated scalar field, as such:

```python
points, U = probe_interpolation(pointsDict)
print(points[:,1]) #distance along probe line
print(U[:]) #interpolated scalar field
```